### PR TITLE
Change package name to event-api-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# user-event-api-client-js
+# MOLOCO RMP Event API Client for JavaScript
+
+JavaScript/TypeScript library for MOLOCO RMP Event API
+
+TODO: add installation instructions

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@moloco-rmp/user-event-api-client",
+  "name": "@moloco-rmp/event-api-client",
   "version": "0.1.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Change package name from `user-event-api-client` to `event-api-client` to align with the API documentation.